### PR TITLE
Bugfix: see dot stderr, drop extra ,box

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,13 +92,14 @@ func main() {
 		log.Fatal(err)
 	}
 	cmd.Stdout = out
+	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Fprintf(in, "digraph {\n")
 	keys := keys()
 	for p, i := range keys {
-		fmt.Fprintf(in, "\tN%d [label=%q,shape=box,box];\n", i, p)
+		fmt.Fprintf(in, "\tN%d [label=%q,shape=box];\n", i, p)
 	}
 	for k, v := range pkgs {
 		for _, p := range v {


### PR DESCRIPTION
The generated dot input used `shape=box,box` where the `,box` is
extraneous and rejected as a syntax error, at least in graphviz 2.32.0
(20130816.0025).  Fix that.

Plumb stderr from the invoked dot command through to the program's own
stderr, to see diagnostics.

@davecheney
