### PR TITLE
correct race between OpenReader and Wait

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 // Graphpkg produces an svg graph of the dependency tree of a package
-// 
+//
 // Requires
 // - dot (graphviz)
 //
@@ -117,7 +117,13 @@ func main() {
 	fmt.Fprintf(in, "}\n")
 	in.Close()
 
-	go browser.OpenReader(out)
+	ch := make(chan error)
+	go func() {
+		ch <- browser.OpenReader(out)
 
+	}()
 	check(cmd.Wait())
+	if err := <-ch; err != nil {
+		log.Fatalf("unable to open browser: %s", err)
+	}
 }


### PR DESCRIPTION
The cmd.Wait can finish before the OpenReader has consumed all of the command's output pipe reader. Since the OpenReader is a non-main goroutine, it doesn't stop the process from exiting unless we give the main goroutine a reason to wait.

This PR does that by adding a little channel to the mix.

Fixes #3