### PR TITLE
include just the graphpkg in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ First install [graphviz](http://graphviz.org/Download.php) for your OS, then
 
 To graph the dependencies of the net package:
 
-	x-www-browser $(graphpkg net)
+	graphpkg net
 
 # Filtering
 
 graphpkg can also filter out packages that do not match the supplied regex, this may improve the readability of some graphs by excluding the std library:
 
-	x-www-browser $(graphpkg -match 'launchpad.net' launchpad.net/goamz/s3)
+	graphpkg -match 'launchpad.net' launchpad.net/goamz/s3


### PR DESCRIPTION
On OS X, you just call graphpkg on its own. I think this works this same on Linux?

Don't have a linux desktop to test on. Let me know if I'm wrong and I'll just add lingo about OS X.