### PR TITLE
Flag to print to standard output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ To graph the dependencies of the net package:
 graphpkg can also filter out packages that do not match the supplied regex, this may improve the readability of some graphs by excluding the std library:
 
 	graphpkg -match 'launchpad.net' launchpad.net/goamz/s3
+
+# Output
+
+By default graphpkg shows the graph in your browser, you can choose to print the resulting svg to standard output:
+
+	graphpkg -stdout -match 'github.com' github.com/davecheney/graphpkg


### PR DESCRIPTION
This PR adds a new `-stdout` boolean flag to the cli, allowing to print the resulting svg to standard output.
This is false by default so the current behaviour is unchanged.